### PR TITLE
Configure trusted publishing for npm package

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -6,20 +6,21 @@ on:
     types: [completed]
     branches: [main]
 
+permissions:
+  id-token: write # Required for OIDC
+  contents: read
+
 jobs:
   publish_to_npm:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    permissions:
-      actions: write # “andymckay/cancel-action” requires “write” access to the “actions” permission
-      id-token: write # Provenance generation in GitHub Actions requires “write” access to the “id-token” permission
     steps:
       -
         name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       -
         name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '18.18.0'
           registry-url: 'https://registry.npmjs.org'
@@ -47,6 +48,4 @@ jobs:
       -
         name: Publish to npm
         if: ${{ steps.check.outputs.VERSION_CHANGED == 'true' }}
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public


### PR DESCRIPTION
### TL;DR

Updated GitHub Actions workflow for npm publishing with improved security and newer action versions.

### What changed?

- Moved permissions from job level to workflow level for better security
- Removed the `actions: write` permission as it's no longer needed
- Updated `actions/checkout` from v4 to v6
- Updated `actions/setup-node` from v4 to v6
- Removed the `--provenance` flag from the npm publish command
- Removed the `NODE_AUTH_TOKEN` environment variable and associated secret

### How to test?

1. Trigger the workflow by completing a successful run on the main branch
2. Verify that the npm package is published correctly without using the token-based authentication
3. Confirm that the OIDC-based authentication works properly with the id-token permission

### Why make this change?

This change modernizes the npm publishing workflow by:
1. Using the latest versions of GitHub Actions
2. Adopting a more secure approach by moving to OIDC-based authentication instead of token-based authentication
3. Simplifying the workflow by removing unnecessary permissions and environment variables
4. Following best practices by defining permissions at the workflow level