### PR TITLE
Fix CLI path handling in tests

### DIFF
--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -485,7 +485,7 @@ function calculateDirectorySize(directoryPath) {
 }
 
 function runCliWithParameters(parameters) {
-	return execSync(`node ${cliPath} ${parameters}`).toString();
+	return execSync(`node "${cliPath}" ${parameters}`).toString();
 }
 
 function grepTotalRatio(string) {


### PR DESCRIPTION
### TL;DR

Fixed CLI test execution by properly quoting the CLI path.

### What changed?

Added double quotes around the CLI path in the `runCliWithParameters` function to ensure proper handling of paths with spaces.

### How to test?

1. Run the CLI tests with the codebase in a path containing spaces
2. Verify that the tests execute successfully without path-related errors

### Why make this change?

Paths often contain spaces and special characters that can cause issues when not properly quoted in command execution. This fix ensures that the CLI tests run reliably across all operating systems, by properly escaping the path to the CLI executable.