### PR TITLE
Update macOS CI runners

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -15,8 +15,8 @@ jobs:
         os: [
             ubuntu-latest, # x64
             ubuntu-24.04-arm, # arm64
-            macos-13, # x64
-            macos-latest, # arm64
+            macos-15-intel, # x64
+            macos-15, # arm64
           ]
     steps:
       - name: Checkout repository


### PR DESCRIPTION
### TL;DR

Updated macOS runner versions in the CI workflow.

### What changed?

- Replaced `macos-13` with `macos-15-intel` for x64 architecture
- Replaced `macos-latest` with `macos-15` for arm64 architecture

### How to test?

Run the CI workflow to verify that the jobs execute successfully on the updated macOS runners.

### Why make this change?

This change updates the macOS runners to use the latest available versions, ensuring the CI pipeline runs on more current environments. Using explicit version numbers (`macos-15` and `macos-15-intel`) instead of `macos-latest` also provides better consistency and predictability in the CI process.